### PR TITLE
Fixed "modThreadId"  in "combatactivators.version"

### DIFF
--- a/combatactivators.version
+++ b/combatactivators.version
@@ -1,7 +1,7 @@
 {
     "masterVersionFile":"https://raw.githubusercontent.com/scardwell15/combatactivators/main/combatactivators.version",
     "modName":"Combat Activators",
-    "modThreadId":24660,
+    "modThreadId":26410,
     "modVersion":
     {
         "major":1,


### PR DESCRIPTION
Changed the "modThreadId" from 24660 which is Exotica Technologies to 26410 which is Combat Activators